### PR TITLE
Bump DiffEqBase to v7, SciMLBase to v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,11 @@ RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-DiffEqBase = "6"
+DiffEqBase = "6, 7"
 PrecompileTools = "1"
 RCall = "0.14"
 Reexport = "1.0"
+SciMLBase = "2, 3"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary

- Expands the `DiffEqBase` compat entry to `"6, 7"` so the package can resolve against DiffEqBase v7, which transitively pulls in SciMLBase v3 and RecursiveArrayTools v4.
- Adds a `SciMLBase = "2, 3"` compat entry.
- Supersedes the dependabot PR #42, which only allowed the new major without vetting the breaking-change surface.

## Why no source changes are needed

The v7 breakage list from the release notes is large, but this package only touches a narrow slice of the API:
- `DiffEqBase.AbstractODEAlgorithm`, `DiffEqBase.AbstractODEProblem`, `DiffEqBase.isinplace`, `DiffEqBase.__solve`, `DiffEqBase.build_solution`, and `ReturnCode.Success` — all still present and unchanged in DiffEqBase v7 / SciMLBase v3.
- No `u_modified!`/`derivative_discontinuity!`, `destats`/`stats`, `DEAlgorithm`/`DEProblem`/`DESolution`, `has_destats`, `concrete_solve`, `fastpow`, `construct*` tableaus, `alias_u0`/`alias_du0`, `chunk_size`, `standardtag`, `QuadratureProblem`, ensemble `prob_func`/`output_func` callbacks, or RAT v4-sensitive indexing (`sol[i]`, `length(sol)`, `iterate(sol)`, `first(sol)`, `last(sol)`) anywhere in `src/` or `test/`.

So the only required change is the compat bump.

## Test plan

- [x] `Pkg.resolve()` picks up DiffEqBase v7.0.0, SciMLBase v3.4.0, RecursiveArrayTools v4.2.0 on both Julia 1.10 and Julia 1.12 with the new compat.
- [x] `Pkg.test()` passes locally on Julia 1.12 with an R + deSolve install (conda-forge `r-base` 4.5.3, deSolve from CRAN):
  - `retcode is Success` testset: 2/2 pass
  - `AllocCheck - Algorithm Name Functions`: 17/17 pass
  - All 16 algorithm smoke solves (lsoda, lsode, lsodes, lsodar, vode, daspk, euler, rk4, ode23, ode45, radau, bdf, bdf_d, adams, impAdams, impAdams_d) succeed.
- [x] Runic format check (`format_string`) — `src/deSolveDiffEq.jl` and `test/runtests.jl` unchanged.
- [ ] CI on Julia 1 and lts, ubuntu / macOS / windows — relies on the GH runner's native R install; the package code is untouched so behavior should match the old compat path.

Closes #42.