### PR TITLE
Migrate Runic/SpellCheck to centralized SciML/.github workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,22 +1,17 @@
-name: format-check
+name: "Format Check"
 
 on:
   push:
     branches:
-      - 'master'
-      - 'main'
-      - 'release-'
-    tags: '*'
+      - master
+    tags: ["*"]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,13 +1,12 @@
-name: Spell Check
+name: "Spell Check"
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Normalizes CI toward the SciML centralized reusable workflows (`SciML/.github`, pinned `@v1`).

## Workflows converted
- **FormatCheck.yml** — was an inline `fredrikekre/runic-action` job; now calls `SciML/.github/.github/workflows/runic.yml@v1` with `secrets: inherit`. Added a `concurrency` group. Runic was already run in this repo, so the code is already formatted — **no formatting changes were needed** (`Runic.main(["--check", "."])` passes locally with no diff).
- **SpellCheck.yml** — was an inline `crate-ci/typos@v1.18.0` job; now calls `SciML/.github/.github/workflows/spellcheck.yml@v1` with `secrets: inherit`. The centralized caller pins `crate-ci/typos@v1.47.0`. `typos` run locally reports **no findings** (existing `.typos.toml` covers the Julia/SciML/deSolve vocabulary).

## Workflows intentionally left unchanged / NOT added
- **Tests.yml — left unchanged (NOT migrated).** This package's test suite requires **R** and the **deSolve** R package via RCall (`runtests.jl` calls `solve(prob, deSolveDiffEq.lsoda())` etc., which dispatch into R). The existing `Tests.yml` installs R via `r-lib/actions/setup-r`, sets `LD_LIBRARY_PATH`, and runs `Rscript -e 'install.packages("deSolve")'` before the Julia tests. The centralized `tests.yml@v1` caller has **no mechanism to install R or R packages**, so migrating would break the previously-passing tests. Preserving the existing matrix exactly (julia `["1","lts"]` × `R=release` on ubuntu, plus macOS/`1` and windows/`lts` includes, coverage via Codecov) requires keeping the inline workflow.
- **Downgrade CI — NOT added.** For the same reason (no R setup hook in `downgrade.yml@v1`), a centralized Downgrade job would fail at the R-based solves. Not added to avoid a red check that cannot pass without an R install step.
- **Documentation — NOT added.** No `docs/` directory exists.
- **Downstream, Benchmark, QA — NOT added.** No existing downstream/IntegrationTest, AirspeedVelocity, or QA workflow to migrate.

## Runic formatting
Not applied — repo was already Runic-clean (verified locally with Runic v1.7.0, `--check` exit 0).

## dependabot.yml
- Removed the `crate-ci/typos` per-dependency `ignore` block from the `github-actions` ecosystem (standing policy: keep everything current, no per-dependency ignores).
- Preserved the existing `julia` ecosystem block unchanged (`directories: ["/", "/test"]`, daily, `all-julia-packages` group).

## CompatHelper
No `CompatHelper.yml` present — nothing to remove.

## Typos findings
None.

## Branch protection
Check names change: `format-check` → the centralized **Runic Format Check** job, and the Spell Check job name changes to **Spell Check with Typos** (reusable). Branch-protection required-status-checks must be updated accordingly after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)