### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/RunicSuggestions.yml
+++ b/.github/workflows/RunicSuggestions.yml
@@ -1,0 +1,9 @@
+name: "Runic Suggestions"
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  runic-suggestions:
+    uses: "SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR adds the missing standard SciML centralized workflow caller files. No existing workflows, `Project.toml`, or source code are modified.

**Workflows added:**
- `RunicSuggestions.yml` (auto-format suggestions via `runic-suggestions-on-pr.yml@v1`; repo is Runic-based)
- `DependabotAutoMerge.yml` (`dependabot-automerge.yml@v1`)

(No `DocPreviewCleanup.yml`: this repo has no `docs/` Documenter site.)

These are static caller files that reference the centralized reusable workflows in `SciML/.github` (`@v1`), so no local test runs are needed.

> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)