### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Replaces the inlined `JuliaRegistries/TagBot` job in `.github/workflows/TagBot.yml` with the canonical thin caller to `SciML/.github/.github/workflows/tagbot.yml@v1`.

Not a monorepo (no `lib/` subpackages), so no `tagbot-subpackages` matrix was added.

No `Downgrade.yml`/`DowngradeSublibraries.yml` present, so no downgrade-caller cleanup needed.

`SpellCheck.yml` exists and `.typos.toml` already present at repo root, so no `.typos.toml` starter added.

Ignore until reviewed by @ChrisRackauckas.