### PR TITLE
ci: provision the deSolve R package (r-cran-desolve) for tests

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -16,5 +16,7 @@ jobs:
   tests:
     uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     with:
-      apt-packages: "r-base-dev"
+      # r-base-dev provides R + headers for RCall; r-cran-desolve provides the
+      # deSolve CRAN package that __init__ loads via rimport("deSolve").
+      apt-packages: "r-base-dev r-cran-desolve"
     secrets: "inherit"


### PR DESCRIPTION
## Problem

Every CI test job (Core and QA, all OSes) on `master` is **red**. `deSolveDiffEq`'s `__init__` runs `rimport("deSolve")`, so merely `using deSolveDiffEq` fails to load unless the **deSolve R package** is present:

```
ERROR: LoadError: InitError: REvalError: Error in loadNamespace(name) : there is no package called 'deSolve'
  @ deSolveDiffEq ~/.../src/deSolveDiffEq.jl:9
in expression starting at .../test/runtests.jl:2
Package deSolveDiffEq errored during testing
```

The `Tests.yml` caller installs `r-base-dev`, which provides R itself plus a handful of *recommended* CRAN packages (boot, class, cluster, …) but **not** `deSolve`. R/RCall build fine (`Using R at /usr/lib/R`), so this is purely a missing R-package provisioning gap, not a Julia or RCall problem.

## Fix

Add `r-cran-desolve` to `apt-packages`. Verified against the Ubuntu `noble` archive (the runner image): the `r-cran-desolve` package (v1.42) installs the complete, loadable `deSolve` package — `NAMESPACE`, bytecode (`deSolve.rdb`/`.rdx`), and the compiled `libs/deSolve.so` — into `/usr/lib/R/site-library/deSolve`, which is on R's default `.libPaths()`, so `rimport("deSolve")` resolves it.

This mirrors the pattern already used for the Python-stack wrappers (e.g. SciPyDiffEq's `python3-scipy`).

## Verification

- Confirmed the failing run's cause from the job logs (`there is no package called 'deSolve'`).
- Downloaded `r-cran-desolve_1.42-1_amd64.deb` from the Ubuntu pool and inspected its contents: it ships `Package: deSolve` v1.42 with `NAMESPACE` + `libs/deSolve.so` under `/usr/lib/R/site-library/`. (Could not run R end-to-end locally: no R / no passwordless sudo in this environment.)

Note: this repo has no Downgrade workflow; the only provisioning leg is `Tests.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ignore until reviewed by @ChrisRackauckas.