### PR TITLE
Canonicalize tests to @safetestset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Pkg = "1"
 PrecompileTools = "1"
 RCall = "0.14"
 Reexport = "1.0"
+SafeTestsets = "0.1, 1"
 SciMLBase = "2, 3"
 Test = "1"
 julia = "1.10"
@@ -24,8 +25,9 @@ julia = "1.10"
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "DiffEqBase", "Pkg", "SciMLBase", "Test"]
+test = ["AllocCheck", "DiffEqBase", "Pkg", "SafeTestsets", "SciMLBase", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 deSolveDiffEq = "0518478a-701b-4815-806c-24ad5cb92f09"
 
@@ -10,5 +11,6 @@ deSolveDiffEq = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,9 +1,10 @@
-using deSolveDiffEq
-using Aqua
-using JET
-using Test
+using SafeTestsets
 
-@testset "Aqua" begin
+@safetestset "Aqua" begin
+    using deSolveDiffEq
+    using Aqua
+    using Test
+
     # persistent_tasks disabled: RCall's __init__ calls `rimport`, which `eval`s
     # into a module and breaks incremental precompilation of the child package
     # Aqua spawns, so the check cannot pass until RCall init is precompile-safe.
@@ -11,6 +12,10 @@ using Test
     @test_broken false  # Aqua persistent_tasks: RCall __init__ eval breaks incremental precompile — see https://github.com/SciML/deSolveDiffEq.jl/issues/51
 end
 
-@testset "JET" begin
+@safetestset "JET" begin
+    using deSolveDiffEq
+    using JET
+    using Test
+
     JET.test_package(deSolveDiffEq; target_defined_modules = true)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Test
+using SafeTestsets
 using deSolveDiffEq
 using DiffEqBase
 using SciMLBase
@@ -43,7 +44,21 @@ if GROUP == "All" || GROUP == "Core"
 
     sol = solve(prob, deSolveDiffEq.lsoda(), saveat = 0.1)
 
-    @testset "retcode is Success" begin
+    @safetestset "retcode is Success" begin
+        using deSolveDiffEq
+        using DiffEqBase
+        using SciMLBase
+
+        function lorenz(u, p, t)
+            du1 = 10.0(u[2] - u[1])
+            du2 = u[1] * (28.0 - u[3]) - u[2]
+            du3 = u[1] * u[2] - (8 / 3) * u[3]
+            return [du1, du2, du3]
+        end
+        u0 = [1.0; 0.0; 0.0]
+        tspan = (0.0, 100.0)
+        prob = ODEProblem(lorenz, u0, tspan)
+
         sol = solve(prob, deSolveDiffEq.lsoda())
         @test sol.retcode == DiffEqBase.ReturnCode.Success
         @test SciMLBase.successful_retcode(sol)
@@ -53,7 +68,11 @@ if GROUP == "All" || GROUP == "Core"
     # Allocation tests for pure Julia helper functions
     # Note: The main solve function allocates due to R interop (RCall),
     # so we only test the Julia-side helper functions
-    @testset "AllocCheck - Algorithm Name Functions" begin
+    @safetestset "AllocCheck - Algorithm Name Functions" begin
+        using deSolveDiffEq
+        using AllocCheck
+        using Test
+
         # Test that algname functions are allocation-free (compile-time constants)
         algs = (
             deSolveDiffEq.lsoda(), deSolveDiffEq.lsode(), deSolveDiffEq.lsodes(),


### PR DESCRIPTION
## Summary

Canonicalizes the test suite to use `@safetestset` so each independent test unit runs in its own module, matching OrdinaryDiffEq's canonical structure (isolation between tests + world-age safety). Behavior-preserving: the same tests run with the same assertions; only the unit wrappers and their import/setup self-containment change.

## Changes

- **`test/runtests.jl`** (Core group): `@testset "retcode is Success"` and `@testset "AllocCheck - Algorithm Name Functions"` -> `@safetestset`. Each body is made self-contained (its own `using deSolveDiffEq`/`DiffEqBase`/`SciMLBase`/`AllocCheck`/`Test` plus the `lorenz`/`u0`/`tspan`/`prob` setup it needs). The `GROUP`-dispatch ladder and the file-scope smoke-`solve` block are left unchanged.
- **`test/qa/qa.jl`**: `@testset "Aqua"` and `@testset "JET"` -> `@safetestset`, each with its own imports. The existing `@test_broken false` (Aqua `persistent_tasks` / RCall precompile, issue #51) is preserved verbatim.
- **Deps**: added `SafeTestsets` to the root `[extras]` / `[targets].test` / `[compat] SafeTestsets = "0.1, 1"`, and to `test/qa/Project.toml` (the QA group activates its own env).

All macros inside the converted bodies are Base/Test only (`@allocated`, `@test`, `@test_broken`), so no package-macro / world-age gotcha applies and inline bodies are safe.

## Verification

Verified locally with `julia +1.11`:
- `GROUP=Core Pkg.test()` -> `retcode is Success` 2/2 pass, `AllocCheck - Algorithm Name Functions` 17/17 pass.
- `GROUP=QA Pkg.test()` -> `Aqua` 10 pass + 1 broken (the preserved `@test_broken`), `JET` 1/1 pass.

(R + deSolve interop was available in the test environment, so the Core smoke-`solve` calls ran for real.)

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)