### PR TITLE
CI: run Core/QA ubuntu-only so apt R provisioning routes to a hosted runner

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,6 +1,9 @@
+# Core/QA run ubuntu-only: the centralized caller provisions R + the deSolve R
+# package (which RCall needs) via apt, which is Linux-only, and routes
+# apt-packages legs onto a GitHub-hosted ubuntu-24.04 runner. macOS/Windows
+# cells could not get R/deSolve and would stay red, so they are not run.
 [Core]
 versions = ["lts", "1", "pre"]
-os = ["ubuntu-latest", "macOS-latest", "windows-latest"]
 
 [QA]
 versions = ["lts", "1"]


### PR DESCRIPTION
## Problem

`master` is fully red after the CI conversion. Every test cell fails at the
**"Install system packages"** step:

```
sudo: a terminal is required to read the password ...
sudo: a password is required
##[error]Process completed with exit code 1.
```

The centralized caller runs `sudo apt-get install -y r-base-dev r-cran-desolve`
(needed because deSolveDiffEq's `__init__` calls `rimport("deSolve")`). On the
self-hosted **demeter** pool there is no passwordless sudo, so apt aborts. On a
self-hosted machine that *did* have a pre-configured R (**arctic**), apt
succeeded but RCall's `initEmbeddedR` then errored against a stale R, so
`SciMLBaseRCallExt` / `deSolveDiffEq` failed to precompile. Either way: red.

## Fix (config-only)

`SciML/.github@v1` `tests.yml` already pins any `apt-packages` leg onto a
GitHub-hosted `ubuntu-24.04` runner (passwordless sudo + a clean R), which fixes
both symptoms. But apt provisioning is **Linux-only**, so the `macOS-latest` /
`windows-latest` Core cells in `test/test_groups.toml` can never get R + the
deSolve R package. And because `apt-packages` is set, the caller force-routes
*every* cell to `ubuntu-24.04` regardless — so those mac/windows cells just
become misleading duplicate ubuntu runs.

So: **drop the `os` axis from `[Core]`** → Core runs ubuntu-only on
`[lts, 1, pre]` (QA was already ubuntu-only). One-line config change.

### OS reduction — for your decision

This drops the macOS/Windows Core cells the pre-conversion CI ran. Restoring
cross-platform R coverage needs a non-config change (cross-platform R
provisioning in the centralized workflow), out of scope for this CI-hygiene
fix. Flagging for your decision.

## Verification

- `test/test_groups.toml` parses; `[Core]` has no `os`, `[QA]` unchanged.
- Ran the real `SciML/.github@v1` `compute_affected_sublibraries.jl . --root-matrix`:
  emits exactly **Core[lts,1,pre] + QA[lts,1], all `runner: ubuntu-latest`**, no
  mac/windows cells. With `apt-packages` set, the caller routes all 5 onto hosted
  `ubuntu-24.04` for the apt step.
- The R-dependent test bodies (Core/QA) cannot run in this sandbox (no R, no
  passwordless sudo); they are exercised by CI on the hosted ubuntu runner.

No test source, algorithm, assertion, or `[compat]` changes — CI config only.

Supersedes the now-diverged #52 (its QA-`develop` fix is obsolete: `master`'s
`run_tests()` harness already `Pkg.develop`s the local package for QA, which is
what #52 hand-rolled).

---
Please ignore until reviewed by @ChrisRackauckas.
