### PR TITLE
Update QA to SciMLTesting 2.1 docs checks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ RCall = "0.14"
 Reexport = "1.0"
 SafeTestsets = "0.1, 1"
 SciMLBase = "2, 3"
-SciMLTesting = "1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -5,12 +5,9 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 deSolveDiffEq = "0518478a-701b-4815-806c-24ad5cb92f09"
 
-[sources]
-deSolveDiffEq = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
-SciMLTesting = "1.7"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
Ignore this draft PR until reviewed by @ChrisRackauckas.

## Summary
- Update SciMLTesting compat to 2.1.
- Remove the repo-local QA [sources] path entry.
- Rely on SciMLTesting public API docs QA instead of repo-local public-doc scanning.

## Validation
- Runic --check on changed Julia files passed; this repo had no changed Julia files.
- TOML.parsefile over assigned Project.toml files passed.
- GROUP=QA julia +1.11 --project=. -e "using Pkg; Pkg.test()" is blocked in this environment: RCall fails during package load because no R installation is configured.