### PR TITLE
Add downgrade compatibility workflow

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,21 @@
+name: Downgrade
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+jobs:
+  test:
+    name: Downgrade
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "lts"
+      group: "Core"
+      apt-packages: "r-base-dev r-cran-desolve"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- add the standard SciML downgrade compatibility workflow on Julia LTS
- route the job to a GitHub-hosted runner and install both R and deSolve through the reusable workflow's `apt-packages` input
- run the existing `Core` test group against the locked dependency floor

## Local verification

- released `julia-actions/julia-downgrade-compat` v2 action (commit `fab1def`): passed
- Julia 1.10 strict floor `Pkg.test` with resolution disabled, R 4.3.3, and RCall 0.14.0: 19/19 passed; `deSolveDiffEq tests passed`
- allocation checks: 17/17 passed
- solver tests: 2/2 passed
- Runic 1.7.0: 5/5 Julia files passed
- actionlint: passed
- `git diff --check`: passed

The local R environment intentionally matches the R generation available to the Ubuntu runner; the existing regular test workflow already uses the same `r-base-dev r-cran-desolve` provisioning.