### PR TITLE
Enable rendered public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,6 +3,10 @@ using JET
 
 run_qa(
     deSolveDiffEq;
+    api_docs_kwargs = (;
+        rendered = true,
+        rendered_ignore = Tuple(names(deSolveDiffEq.DiffEqBase)),
+    ),
     explicit_imports = true,
     jet_kwargs = (; target_defined_modules = true),
     # persistent_tasks: RCall's __init__ calls `rimport`, which `eval`s into a


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- Enables SciMLTesting rendered public API docs coverage for deSolveDiffEq.
- Ignores DiffEqBase-owned reexports for rendered coverage. deSolveDiffEq has no package-owned `export`, Julia `public`, or `@public` declarations on current `master`.
- Does not add docs, docstrings, `[sources]`, or package path source entries.

## Validation

- `git diff --check`: passed.
- Runic v1.7.0 `--check src test`: passed.
- Local `Pkg.test()` / QA could not run to completion in this container because `R` is not installed (`R: command not found`) and the checked-in manifest is resolved with a newer Julia version, causing Julia 1.10 to fail before tests with missing `StyledStrings`. The repository CI installs `r-base-dev r-cran-desolve`, so the PR is left draft for CI validation.
