### PR TITLE
Use inherited public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,10 +3,6 @@ using JET
 
 run_qa(
     deSolveDiffEq;
-    api_docs_kwargs = (;
-        rendered = true,
-        rendered_ignore = Tuple(names(deSolveDiffEq.DiffEqBase)),
-    ),
     explicit_imports = true,
     jet_kwargs = (; target_defined_modules = true),
     # persistent_tasks: RCall's __init__ calls `rimport`, which `eval`s into a


### PR DESCRIPTION
Removes the package-specific DiffEqBase rendered-doc ignore list. Inherited public bindings are verified at their defining package by SciMLTesting #27.

Depends on https://github.com/SciML/SciMLTesting.jl/pull/27.

Ignore until reviewed by @ChrisRackauckas.