### PR TITLE
Load without the R deSolve package (warn loudly instead of failing import)

### DIFF
--- a/src/deSolveDiffEq.jl
+++ b/src/deSolveDiffEq.jl
@@ -7,10 +7,20 @@ using PrecompileTools: @setup_workload, @compile_workload
 using DiffEqBase: DiffEqBase, ODEProblem, ReturnCode
 using SciMLBase: SciMLBase
 
-solver = Ref{Module}()
+const solver = Ref{Module}()
 
 function __init__()
-    return solver[] = rimport("deSolve")
+    try
+        solver[] = rimport("deSolve")
+    catch err
+        @warn """
+        deSolveDiffEq.jl loaded but could not import the R `deSolve` package, so no \
+        solver is available. Solving with a deSolveDiffEq algorithm will error until R \
+        and the `deSolve` package are installed and reachable through RCall.jl. Install \
+        it from R with `install.packages("deSolve")`.
+        """ exception = (err, catch_backtrace())
+    end
+    return nothing
 end
 
 abstract type deSolveAlgorithm <: SciMLBase.AbstractODEAlgorithm end
@@ -60,6 +70,11 @@ function SciMLBase.__solve(
         maxiters = 100000,
         kwargs...
     )
+    isassigned(solver) || error(
+        "deSolveDiffEq: the R `deSolve` package is not available. Install R and run " *
+        "`install.packages(\"deSolve\")` so RCall.jl can load it, then restart Julia."
+    )
+
     p = prob.p
     tspan = prob.tspan
     u0 = prob.u0


### PR DESCRIPTION
Makes deSolveDiffEq.jl importable even when R / the R `deSolve` package is missing, unblocking registration.

## Problem
`__init__` called `rimport("deSolve")` unconditionally. When R/deSolve is absent (as in the General AutoMerge sandbox), `__init__` throws, so `import deSolveDiffEq` fails — which is why the v1.2.1 registration (JuliaRegistries/General) stalls on "I was not able to load the package".

## Fix
- Guard the `rimport("deSolve")` in `__init__` with `try`/`catch` + a loud `@warn`, so the module loads regardless.
- `solver` is now a `const` `Ref`, and `SciMLBase.__solve` raises a clear, actionable error if the solver was never initialized (instead of a cryptic `UndefRefError`).

The working path is unchanged when R/deSolve is present.

## Verification
`Meta.parseall` clean. **Note:** I could not run `using deSolveDiffEq` locally to completion because R is not installed on this machine, so `RCall` itself cannot precompile here — that is an environment limitation, not a code path this PR changes. The fix mirrors the verified-working FEniCS.jl change (same `__init__` try/catch pattern); the real check is this PR’s CI / the General AutoMerge re-run.

Please ignore until reviewed by @ChrisRackauckas.