### PR TITLE
Migrate to strict SciMLTesting 2.4 QA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,34 +1,36 @@
 name = "deSolveDiffEq"
 uuid = "0518478a-701b-4815-806c-24ad5cb92f09"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.3.0"
+version = "2.0.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+
+[weakdeps]
+RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
+
+[extensions]
+deSolveDiffEqRCallExt = "RCall"
 
 [compat]
 AllocCheck = "0.1, 0.2"
 DiffEqBase = "6, 7"
 PrecompileTools = "1.1"
 RCall = "0.14"
-Reexport = "1.0"
 SafeTestsets = "0.1, 1"
 SciMLBase = "2, 3"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"
 
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "DiffEqBase", "SafeTestsets", "SciMLBase", "SciMLTesting", "Test"]
+test = ["AllocCheck", "SafeTestsets", "SciMLBase", "SciMLTesting", "Test"]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ deSolveDiffEq.impAdams_d()
 ## Example
 
 ```julia
-using deSolveDiffEq
+using SciMLBase, deSolveDiffEq, RCall
 
 function lorenz(u, p, t)
     du1 = 10.0(u[2]-u[1])
@@ -102,7 +102,7 @@ RObject{RealSxp}
 vs the deSolveDiffEq.jl approach:
 
 ```julia
-using deSolveDiffEq, BenchmarkTools
+using SciMLBase, deSolveDiffEq, RCall, BenchmarkTools
 
 function lorenz(u, p, t)
     du1 = 10.0(u[2]-u[1])

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+deSolveDiffEq = "0518478a-701b-4815-806c-24ad5cb92f09"
+
+[compat]
+Documenter = "1"
+julia = "1.10"
+
+[sources]
+deSolveDiffEq = {path = ".."}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,9 @@
+using Documenter
+using deSolveDiffEq
+
+makedocs(
+    sitename = "deSolveDiffEq.jl",
+    modules = [deSolveDiffEq],
+    checkdocs = :exports,
+    doctest = true,
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,39 @@
+# deSolveDiffEq.jl
+
+`deSolveDiffEq.jl` integrates the R [deSolve](https://desolve.r-forge.r-project.org/)
+solvers with the SciML solve interface. Load `RCall` before solving so the package's
+RCall extension can initialize the R-backed algorithms.
+
+## Algorithms
+
+```@docs
+deSolveAlgorithm
+lsoda
+lsode
+lsodes
+lsodar
+vode
+daspk
+euler
+rk4
+ode23
+ode45
+radau
+bdf
+bdf_d
+adams
+impAdams
+impAdams_d
+iteration
+```
+
+```jldoctest; setup = :(using deSolveDiffEq)
+julia> deSolveDiffEq.lsoda() isa deSolveDiffEq.deSolveAlgorithm
+true
+```
+
+## Solver Extension Contract
+
+Solver packages implement the documented `SciMLBase.__solve` interface for their
+algorithm types. `deSolveDiffEq` implements that interface for every subtype of
+`deSolveAlgorithm`; callers should use `SciMLBase.solve`.

--- a/ext/deSolveDiffEqRCallExt.jl
+++ b/ext/deSolveDiffEqRCallExt.jl
@@ -1,0 +1,11 @@
+module deSolveDiffEqRCallExt
+
+using deSolveDiffEq
+using RCall
+
+function __init__()
+    deSolveDiffEq.rcall_adapter[] = RCall
+    return nothing
+end
+
+end

--- a/ext/deSolveDiffEqRCallExt.jl
+++ b/ext/deSolveDiffEqRCallExt.jl
@@ -4,7 +4,7 @@ using deSolveDiffEq
 using RCall
 
 function __init__()
-    deSolveDiffEq.rcall_adapter[] = RCall
+    deSolveDiffEq.r_adapter[] = RCall
     return nothing
 end
 

--- a/src/deSolveDiffEq.jl
+++ b/src/deSolveDiffEq.jl
@@ -9,11 +9,11 @@ export deSolveAlgorithm, lsoda, lsode, lsodes, lsodar, vode, daspk, euler, rk4, 
     ode45, radau, bdf, bdf_d, adams, impAdams, impAdams_d, iteration
 
 const solver = Ref{Union{Nothing, Module}}(nothing)
-const rcall_adapter = Ref{Any}(nothing)
+const r_adapter = Ref{Any}(nothing)
 
 function deSolve_solver()
     solver[] !== nothing && return solver[]
-    RCall = rcall_adapter[]
+    RCall = r_adapter[]
     RCall === nothing && error(
         "deSolveDiffEq: RCall must be loaded before solving with a deSolveDiffEq algorithm.",
     )
@@ -170,7 +170,7 @@ function SciMLBase.__solve(
         maxiters = 100000,
         kwargs...
     )
-    RCall = rcall_adapter[]
+    RCall = r_adapter[]
     RCall === nothing && error(
         "deSolveDiffEq: RCall must be loaded before solving with a deSolveDiffEq algorithm.",
     )

--- a/src/deSolveDiffEq.jl
+++ b/src/deSolveDiffEq.jl
@@ -1,17 +1,24 @@
 module deSolveDiffEq
 
-using Reexport: @reexport
-using RCall: @R_str, rcopy, rimport
 using PrecompileTools: @setup_workload, @compile_workload
-@reexport using DiffEqBase
-using DiffEqBase: DiffEqBase, ODEProblem, ReturnCode
-using SciMLBase: SciMLBase
+import DiffEqBase
+using SciMLBase: ODEProblem, ReturnCode
+import SciMLBase
 
-const solver = Ref{Module}()
+export deSolveAlgorithm, lsoda, lsode, lsodes, lsodar, vode, daspk, euler, rk4, ode23,
+    ode45, radau, bdf, bdf_d, adams, impAdams, impAdams_d, iteration
 
-function __init__()
+const solver = Ref{Union{Nothing, Module}}(nothing)
+const rcall_adapter = Ref{Any}(nothing)
+
+function deSolve_solver()
+    solver[] !== nothing && return solver[]
+    RCall = rcall_adapter[]
+    RCall === nothing && error(
+        "deSolveDiffEq: RCall must be loaded before solving with a deSolveDiffEq algorithm.",
+    )
     try
-        solver[] = rimport("deSolve")
+        return solver[] = RCall.rimport("deSolve")
     catch err
         @warn """
         deSolveDiffEq.jl loaded but could not import the R `deSolve` package, so no \
@@ -19,28 +26,121 @@ function __init__()
         and the `deSolve` package are installed and reachable through RCall.jl. Install \
         it from R with `install.packages("deSolve")`.
         """ exception = (err, catch_backtrace())
+        error(
+            "deSolveDiffEq: the R `deSolve` package is not available. Install R and run " *
+                "`install.packages(\"deSolve\")` so RCall.jl can load it, then restart Julia.",
+        )
     end
-    return nothing
 end
 
+"""
+    deSolveAlgorithm
+
+Abstract supertype for algorithms provided by the R `deSolve` package.
+"""
 abstract type deSolveAlgorithm <: SciMLBase.AbstractODEAlgorithm end
 
+"""
+    lsoda()
+
+Select the R `deSolve` `lsoda` algorithm.
+"""
 struct lsoda <: deSolveAlgorithm end
+"""
+    lsode()
+
+Select the R `deSolve` `lsode` algorithm.
+"""
 struct lsode <: deSolveAlgorithm end
+"""
+    lsodes()
+
+Select the R `deSolve` `lsodes` algorithm.
+"""
 struct lsodes <: deSolveAlgorithm end
+"""
+    lsodar()
+
+Select the R `deSolve` `lsodar` algorithm.
+"""
 struct lsodar <: deSolveAlgorithm end
+"""
+    vode()
+
+Select the R `deSolve` `vode` algorithm.
+"""
 struct vode <: deSolveAlgorithm end
+"""
+    daspk()
+
+Select the R `deSolve` `daspk` algorithm.
+"""
 struct daspk <: deSolveAlgorithm end
+"""
+    euler()
+
+Select the R `deSolve` `euler` algorithm.
+"""
 struct euler <: deSolveAlgorithm end
+"""
+    rk4()
+
+Select the R `deSolve` `rk4` algorithm.
+"""
 struct rk4 <: deSolveAlgorithm end
+"""
+    ode23()
+
+Select the R `deSolve` `ode23` algorithm.
+"""
 struct ode23 <: deSolveAlgorithm end
+"""
+    ode45()
+
+Select the R `deSolve` `ode45` algorithm.
+"""
 struct ode45 <: deSolveAlgorithm end
+"""
+    radau()
+
+Select the R `deSolve` `radau` algorithm.
+"""
 struct radau <: deSolveAlgorithm end
+"""
+    bdf()
+
+Select the R `deSolve` `bdf` algorithm.
+"""
 struct bdf <: deSolveAlgorithm end
+"""
+    bdf_d()
+
+Select the R `deSolve` `bdf_d` algorithm.
+"""
 struct bdf_d <: deSolveAlgorithm end
+"""
+    adams()
+
+Select the R `deSolve` `adams` algorithm.
+"""
 struct adams <: deSolveAlgorithm end
+"""
+    impAdams()
+
+Select the R `deSolve` `impAdams` algorithm.
+"""
 struct impAdams <: deSolveAlgorithm end
+"""
+    impAdams_d()
+
+Select the R `deSolve` `impAdams_d` algorithm.
+"""
 struct impAdams_d <: deSolveAlgorithm end
+"""
+    iteration()
+
+Select the R `deSolve` `iteration` algorithm.
+"""
 struct iteration <: deSolveAlgorithm end
 
 # Compile-time algorithm name extraction to avoid runtime string allocations
@@ -70,10 +170,11 @@ function SciMLBase.__solve(
         maxiters = 100000,
         kwargs...
     )
-    isassigned(solver) || error(
-        "deSolveDiffEq: the R `deSolve` package is not available. Install R and run " *
-        "`install.packages(\"deSolve\")` so RCall.jl can load it, then restart Julia."
+    RCall = rcall_adapter[]
+    RCall === nothing && error(
+        "deSolveDiffEq: RCall must be loaded before solving with a deSolveDiffEq algorithm.",
     )
+    deSolve = deSolve_solver()
 
     p = prob.p
     tspan = prob.tspan
@@ -83,12 +184,12 @@ function SciMLBase.__solve(
         f = function (t, u, __p)
             du = similar(u)
             prob.f(du, u, p, t)
-            return R"list($du)" # Error message says a list return is required!
+            return RCall.rcall(:list, du) # Error message says a list return is required!
         end
     else
         f = function (t, u, __p)
             du = prob.f(u, p, t)
-            return R"list($du)" # Error message says a list return is required!
+            return RCall.rcall(:list, du) # Error message says a list return is required!
         end
     end
 
@@ -103,8 +204,8 @@ function SciMLBase.__solve(
         collect(_saveat)
     end
 
-    out = rcopy(
-        solver[].ode(
+    out = RCall.rcopy(
+        deSolve.ode(
             times = __saveat, y = u0, func = f,
             method = algname(alg),
             parms = nothing, maxsteps = maxiters,

--- a/test/extension_contract_tests.jl
+++ b/test/extension_contract_tests.jl
@@ -1,0 +1,35 @@
+using deSolveDiffEq
+using SciMLBase
+using Test
+
+module ExternalSciMLBaseExtension
+
+    using SciMLBase
+
+    struct MockAlgorithm <: SciMLBase.AbstractODEAlgorithm end
+
+    SciMLBase.__solve(
+        ::SciMLBase.AbstractODEProblem,
+        ::MockAlgorithm,
+        args...;
+        kwargs...,
+    ) = :external_extension
+
+end
+
+@testset "Public solver extension contract" begin
+    f(u, p, t) = u
+    prob = SciMLBase.ODEProblem(f, 1.0, (0.0, 1.0))
+
+    @test SciMLBase.solve(prob, ExternalSciMLBaseExtension.MockAlgorithm()) ===
+        :external_extension
+end
+
+@testset "Public algorithms" begin
+    algorithms = (
+        lsoda, lsode, lsodes, lsodar, vode, daspk, euler, rk4, ode23, ode45, radau,
+        bdf, bdf_d, adams, impAdams, impAdams_d, iteration,
+    )
+
+    @test all(algorithm() isa deSolveAlgorithm for algorithm in algorithms)
+end

--- a/test/mock_rcall.jl
+++ b/test/mock_rcall.jl
@@ -1,0 +1,29 @@
+using deSolveDiffEq
+
+module MockRCall
+
+    module MockDeSolve
+
+        function ode(; times, y, func, parms, kwargs...)
+            values = Matrix{eltype(y)}(undef, length(times), length(y) + 1)
+            state = copy(y)
+
+            for (index, time) in pairs(times)
+                values[index, 1] = time
+                values[index, 2:end] .= state
+                state .+= func(time, state, parms)
+            end
+
+            return values
+        end
+
+    end
+
+    rimport(::String) = MockDeSolve
+    rcall(::Symbol, value) = value
+    rcopy(value) = value
+
+end
+
+deSolveDiffEq.rcall_adapter[] = MockRCall
+deSolveDiffEq.solver[] = nothing

--- a/test/mock_rcall.jl
+++ b/test/mock_rcall.jl
@@ -25,5 +25,5 @@ module MockRCall
 
 end
 
-deSolveDiffEq.rcall_adapter[] = MockRCall
+deSolveDiffEq.r_adapter[] = MockRCall
 deSolveDiffEq.solver[] = nothing

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,13 +1,11 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 deSolveDiffEq = "0518478a-701b-4815-806c-24ad5cb92f09"
 
 [compat]
 Aqua = "0.8"
-JET = "0.9,0.10,0.11"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,22 +1,3 @@
-using SciMLTesting, deSolveDiffEq, Test
-using JET
+using SciMLTesting, deSolveDiffEq
 
-run_qa(
-    deSolveDiffEq;
-    explicit_imports = true,
-    jet_kwargs = (; target_defined_modules = true),
-    # persistent_tasks: RCall's __init__ calls `rimport`, which `eval`s into a
-    # module and breaks incremental precompilation of the child package Aqua
-    # spawns, so the check cannot pass until RCall init is precompile-safe.
-    # https://github.com/SciML/deSolveDiffEq.jl/issues/51
-    aqua_broken = (:persistent_tasks,),
-    ei_kwargs = (;
-        # `__solve` is the SciMLBase-owned solve-interface hook this package
-        # extends as `SciMLBase.__solve`. It remains non-public in SciMLBase (and
-        # in DiffEqBase), so the public-API check flags the qualified access even
-        # though it is reached through its owner.
-        all_qualified_accesses_are_public = (;
-            ignore = (:__solve,),
-        ),
-    ),
-)
+run_qa(deSolveDiffEq)

--- a/test/solve_tests.jl
+++ b/test/solve_tests.jl
@@ -1,5 +1,4 @@
 using deSolveDiffEq
-using DiffEqBase
 using SciMLBase
 using Test
 
@@ -34,6 +33,6 @@ sol = solve(prob, deSolveDiffEq.lsoda(), saveat = 0.1)
 
 @testset "retcode is Success" begin
     sol = solve(prob, deSolveDiffEq.lsoda())
-    @test sol.retcode == DiffEqBase.ReturnCode.Success
+    @test sol.retcode == SciMLBase.ReturnCode.Success
     @test SciMLBase.successful_retcode(sol)
 end

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+rcall = "rcall"
+parms = "parms"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- use exact `run_qa(deSolveDiffEq)` with SciMLTesting compat `2.4`
- replace the DiffEqBase facade reexports with documented local algorithm exports and a major version bump
- make RCall a weak dependency extension so QA and docs do not require a local R installation
- add rendered API docs, doctests, and generic external solver-extension/RCall mock coverage

## Validation
- `Pkg.test()`
- exact strict QA: `test/qa/qa.jl`
- `docs/make.jl` with Documenter doctests
- Runic check