### PR TITLE
Make the QA group scan the RCall extension

### DIFF
--- a/ext/deSolveDiffEqRCallExt.jl
+++ b/ext/deSolveDiffEqRCallExt.jl
@@ -1,7 +1,7 @@
 module deSolveDiffEqRCallExt
 
 using deSolveDiffEq
-using RCall
+using RCall: RCall
 
 function __init__()
     deSolveDiffEq.r_adapter[] = RCall

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,11 +1,13 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 deSolveDiffEq = "0518478a-701b-4815-806c-24ad5cb92f09"
 
 [compat]
 Aqua = "0.8"
+RCall = "0.14"
 SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,30 @@
-using SciMLTesting, deSolveDiffEq
+using SciMLTesting, deSolveDiffEq, Test
 
-run_qa(deSolveDiffEq)
+# ExplicitImports can only check an extension module that actually exists, and an
+# extension module only exists once its triggers are loaded. Without this `using`
+# the ext/ sources are never scanned by QA at all. RCall needs a working R
+# installation, which CI provides through the `r-base-dev` apt package.
+using RCall
+
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    for ext in (:deSolveDiffEqRCallExt,)
+        @test Base.get_extension(deSolveDiffEq, ext) !== nothing
+    end
+end
+
+run_qa(
+    deSolveDiffEq;
+    ei_kwargs = (;
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                # deSolveDiffEq's own internal, reached from its own extension.
+                # ExplicitImports treats an extension as a separate module, so this
+                # reads as a non-public cross-module access even though it never
+                # leaves the package.
+                :r_adapter,
+            ),
+        ),
+    ),
+)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## What this fixes

`SciMLTesting.run_qa` runs ExplicitImports, which resolves each `[extensions]` entry
through `Base.get_extension` and silently skips anything that returns `nothing`. An
extension module only exists once its trigger is loaded, and `test/qa` never loaded RCall,
so `deSolveDiffEqRCallExt` was not checked by QA at all.

Before (base branch, `explicit_imports(deSolveDiffEq)`):
```
BASE: get_extension => nothing
BASE SCANNED: deSolveDiffEq
```

After:
```
get_extension => deSolveDiffEqRCallExt
SCANNED: deSolveDiffEq
SCANNED: deSolveDiffEqRCallExt
```

This was a real gap, not incidental coverage — nothing in the QA environment pulled RCall
in transitively.

`qa.jl` also asserts `Base.get_extension(deSolveDiffEq, :deSolveDiffEqRCallExt) !== nothing`.
Without it, a future change that breaks the extension's precompilation would make QA go
green while coverage silently dropped back to zero.

### Extensions now scanned
* `deSolveDiffEqRCallExt` (trigger: RCall)

### Extensions still unscanned
* None. This is the package's only extension.

## Why RCall is safe to add to the QA environment

RCall needs a working R installation. `.github/workflows/Tests.yml` already passes
`apt-packages: "r-base-dev r-cran-desolve"` to `SciML/.github`'s `grouped-tests.yml`, and
that workflow forwards `apt-packages` to *every* matrix leg, not just Core — so the QA
lane gets R too. `test/test_groups.toml` already restricts both Core and QA to Linux for
exactly this reason. The extension's `__init__` only does `r_adapter[] = RCall`; it does
not `rimport("deSolve")`, so QA needs R but not the deSolve CRAN package.

## Findings fixed at the source (not ignored)

* `no_implicit_imports`: `using RCall` → `using RCall: RCall`. The extension only needs the
  module binding (it stores `RCall` itself in `r_adapter[]`).

## Ignore entries added

One entry, in `all_qualified_accesses_are_public`:

```julia
# deSolveDiffEq's own internal, reached from its own extension.
# ExplicitImports treats an extension as a separate module, so this
# reads as a non-public cross-module access even though it never
# leaves the package.
:r_adapter,
```

`r_adapter` is the `Ref` declared in `src/deSolveDiffEq.jl` that the extension exists to
populate. It is deliberately not public API, and the access never leaves the package — the
finding is purely an artifact of ExplicitImports modelling an extension as a foreign
module. Same treatment and wording as the ComponentArrays sweep.

No check was disabled, no `@test_broken`, no loosened assertion.

## Local test results

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on this branch:

```
Test Summary: | Pass  Total     Time
QA/qa.jl      |   21     21  1m28.7s
     Testing deSolveDiffEq tests passed
```

(Before the `r_adapter` ignore was added the same run reported `20 passed, 1 errored`,
the error being exactly the finding described above — which confirms the extension really
is being walked now.)

`GROUP=Core` also passes on this branch:

```
     Testing deSolveDiffEq tests passed
```

**Caveat on the local run:** this machine has no system R, so RCall was pointed at a
Conda-provided R (`R_HOME='*'; Pkg.build("RCall")`, giving R 4.5.1) to make local
verification possible. CI will instead use the apt `r-base-dev` R. The RCall/R interaction
here is trivial (load the module, read `RCall` as a value), so the difference should not
matter, but the CI run is the authoritative check that the QA lane can build RCall against
apt R.

Julia 1.12.4, RCall v0.14.