### PR TITLE
Raise DiffEqBase floor to 7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ deSolveDiffEqRCallExt = "RCall"
 
 [compat]
 AllocCheck = "0.1, 0.2"
-DiffEqBase = "6, 7"
+DiffEqBase = "7"
 PrecompileTools = "1.1"
 RCall = "0.14"
 SafeTestsets = "0.1, 1"


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` lower-bound bump:

- `DiffEqBase = "6, 7"` → `"7"`

No solver code, tests, or package version were changed.

## Why

deSolveDiffEq requires `SciMLBase = "2, 3"`, which forces RecursiveArrayTools 2.33–4. DiffEqBase 6.0.0 only supports RecursiveArrayTools 0.16–1.2, so the declared `"6, 7"` floor cannot resolve.

## Verification

Julia 1.10.11, isolated depot, `Pkg.develop` of this checkout, then `Pkg.add`:

| Pin | Result |
|---|---|
| DiffEqBase 6.0.0 (old floor) | unsatisfiable: DiffEqBase 6.0.0 wants RecursiveArrayTools 0.16–1.2; SciMLBase 2–3 requires RAT 2.33–4 |
| DiffEqBase 7.0.0 (new floor) | `RESOLVE_OK` / `LOAD_OK deSolveDiffEq` |
| DiffEqBase 7.12.0 | `RESOLVE_OK` / `LOAD_OK deSolveDiffEq` |

Not verified here: the full test suite, QA, or a live `julia-downgrade-compat` run.
